### PR TITLE
Add Playwright tests for EPAM website

### DIFF
--- a/playwrighttests/epam.spec.ts
+++ b/playwrighttests/epam.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Website Test', () => {
+  test('Navigate to Services and Explore Client Work', async ({ page }) => {
+    // Step 1: Navigate to https://www.epam.com/
+    await page.goto('https://www.epam.com/');
+
+    // Step 2: Select "Services" from the header menu
+    await page.click('header >> text=Services');
+
+    // Step 3: Click the "Explore Our Client Work" link
+    await page.click('text=Explore Our Client Work');
+
+    // Step 4: Verify that the "Client Work" text is visible on the page
+    const clientWorkText = await page.locator('text=Client Work');
+    await expect(clientWorkText).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request adds a new Playwright test scenario to the 'playwrighttests/' directory. The test covers the following steps:

1. Navigate to https://www.epam.com/
2. Select 'Services' from the header menu.
3. Click the 'Explore Our Client Work' link.
4. Verify that the 'Client Work' text is visible on the page.

The test ensures that the 'Client Work' section is accessible from the Services menu.