### PR TITLE
Add Playwright tests for EPAM website

### DIFF
--- a/playwrighttests/clientWork.test.ts
+++ b/playwrighttests/clientWork.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work section on EPAM website', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu.
+  await page.click('text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link.
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page.
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds Playwright tests to verify the "Client Work" section on the EPAM website.

**Test Scenario:**
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

The test script is located in the 'playwrighttests/' directory.

closes #3