### PR TITLE
Add Playwright test scenario for EPAM website navigation

### DIFF
--- a/playwrighttests/test_scenario.spec.ts
+++ b/playwrighttests/test_scenario.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to EPAM Services and verify Client Work', async ({ page }) => {
+  // Navigate to the EPAM website
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test scenario to navigate to the EPAM website, select "Services" from the header menu, click the "Explore Our Client Work" link, and verify that the "Client Work" text is visible on the page.