### PR TITLE
Add Playwright tests for EPAM Client Work page

### DIFF
--- a/playwrighttests/epamClientWorkTest.spec.ts
+++ b/playwrighttests/epamClientWorkTest.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work Test', async ({ page }) => {
+  // Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu.
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link.
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page.
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
Added a new Playwright test script to verify the visibility of 'Client Work' text on the EPAM website.

Test steps include:
- Navigating to https://www.epam.com/
- Selecting 'Services' from the header menu
- Clicking the 'Explore Our Client Work' link
- Verifying that the 'Client Work' text is visible on the page