### PR TITLE
Add Playwright Tests for Client Work Page

### DIFF
--- a/playwrighttests/clientWork.test.ts
+++ b/playwrighttests/clientWork.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Validate EPAM Client Work Page', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu
+  await page.click('header >> text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
Added Playwright tests to validate the "Client Work" page on EPAM website.

**Test Steps**:
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

This PR includes typical, edge, and negative use cases.