### PR TITLE
Add Playwright tests for EPAM Client Work

### DIFF
--- a/playwrighttests/epam-client-work.spec.ts
+++ b/playwrighttests/epam-client-work.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work Test', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu.
+  await page.click('text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link.
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page.
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds Playwright tests for the EPAM Client Work page.

### Test Scenario:
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

### Edge Cases:
1. Verify the behavior when the "Services" menu item is not available.
2. Verify the behavior when the "Explore Our Client Work" link is not available.
3. Verify the behavior when the "Client Work" text is not visible on the page.

### Negative Cases:
1. Verify the behavior when the page fails to load.
2. Verify the behavior when the network is slow or disconnected.