### PR TITLE
Add Client Work Test

### DIFF
--- a/playwrighttests/clientWorkTest.ts
+++ b/playwrighttests/clientWorkTest.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work text visibility', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
Added a Playwright test to verify the visibility of the 'Client Work' text on the EPAM website.

Steps:
1. Navigate to https://www.epam.com/
2. Select 'Services' from the header menu.
3. Click the 'Explore Our Client Work' link.
4. Verify that the 'Client Work' text is visible on the page.