### PR TITLE
Add Playwright test for EPAM Client Work verification

### DIFF
--- a/playwrighttests/test-epam-client-work.spec.ts
+++ b/playwrighttests/test-epam-client-work.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to EPAM and verify Client Work', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  await page.waitForLoadState('domcontentloaded');
+
+  // Step 2: Select "Services" from the header menu.
+  await page.hover('text=Services');
+  await page.waitForTimeout(1000); // Wait for the dropdown to appear
+
+  // Step 3: Click the "Explore Our Client Work" link.
+  await page.click('text=Explore Our Client Work');
+  await page.waitForLoadState('domcontentloaded');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page.
+  const clientWorkText = await page.isVisible('text=Client Work');
+  expect(clientWorkText).toBe(true);
+});


### PR DESCRIPTION
### Summary

- Added a Playwright test to navigate to EPAM website, select 'Services' from the header menu, click 'Explore Our Client Work' link, and verify that the 'Client Work' text is visible on the page.

### Changes

- Created a new test file `playwrighttests/test-epam-client-work.spec.ts` with the test scenario.

### Instructions

- Execute the test to ensure it passes successfully.