### PR TITLE
Add Epam Client Work Test

### DIFF
--- a/playwrighttests/epamClientWorkTest.ts
+++ b/playwrighttests/epamClientWorkTest.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('Navigate to Epam and verify Client Work text', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  
+  // Step 2: Select "Services" from the header menu
+  await page.waitForSelector('header'); // Wait for the header to be visible
+  await page.click('text=Services');
+  
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.waitForSelector('text=Explore Our Client Work'); // Wait for the link to be visible
+  await page.click('text=Explore Our Client Work');
+  
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  await page.waitForSelector('text=Client Work'); // Wait for the text to be visible
+  const clientWorkText = await page.isVisible('text=Client Work');
+  expect(clientWorkText).toBe(true);
+});


### PR DESCRIPTION
This PR adds a Playwright test to navigate to Epam website, select "Services" from the header menu, click the "Explore Our Client Work" link, and verify that the "Client Work" text is visible on the page.