### PR TITLE
Add Playwright tests for EPAM Client Work

### DIFF
--- a/playwrighttests/epam-client-work.spec.ts
+++ b/playwrighttests/epam-client-work.spec.ts
@@ -1,5 +1,25 @@
 import { test, expect } from '@playwright/test';
 
+test('Navigate to EPAM Client Work', async ({ page }) => {
+  // Navigate to the EPAM website
+  await page.goto('https://www.epam.com/');
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Select "Services" from the header menu
+  const servicesMenu = await page.waitForSelector('text=Services');
+  await servicesMenu.click();
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Click the "Explore Our Client Work" link
+  const clientWorkLink = await page.waitForSelector('text=Explore Our Client Work');
+  await clientWorkLink.click();
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.waitForSelector('text=Client Work');
+  expect(clientWorkText).toBeTruthy();
+});
+
 test('EPAM Client Work Test', async ({ page }) => {
   // Step 1: Navigate to https://www.epam.com/
   await page.goto('https://www.epam.com/');


### PR DESCRIPTION
This pull request adds Playwright tests to automate the following scenario:

1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

The tests include waits to ensure elements are loaded before interacting with them.