### PR TITLE
Add test for verifying Client Work text visibility

### DIFF
--- a/playwrighttests/test-epam-client-work.spec.ts
+++ b/playwrighttests/test-epam-client-work.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work text is visible', async ({ page }) => {
+  // Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Select "Services" from the header menu
+  const servicesMenu = page.locator('text=Services');
+  await servicesMenu.click();
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Click the "Explore Our Client Work" link
+  const clientWorkLink = page.locator('text=Explore Our Client Work');
+  await clientWorkLink.click();
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a Playwright test script to verify that the 'Client Work' text is visible on the EPAM website. The test scenario includes navigating to the website, selecting 'Services' from the header menu, clicking the 'Explore Our Client Work' link, and verifying the visibility of the 'Client Work' text.