### PR TITLE
Add Playwright tests for EPAM Client Work page

### DIFF
--- a/playwrighttests/epam-client-work.spec.ts
+++ b/playwrighttests/epam-client-work.spec.ts
@@ -1,5 +1,25 @@
 import { test, expect } from '@playwright/test';
 
+test('Navigate to EPAM and verify Client Work', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  await page.waitForLoadState('domcontentloaded');
+
+  // Step 2: Select "Services" from the header menu.
+  const servicesMenu = page.locator('header >> text=Services');
+  await servicesMenu.click();
+  await page.waitForTimeout(2000); // Wait for 2 seconds to ensure the menu is loaded
+
+  // Step 3: Click the "Explore Our Client Work" link.
+  const exploreClientWorkLink = page.locator('text=Explore Our Client Work');
+  await exploreClientWorkLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page.
+  const clientWorkText = page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});
+
 test('EPAM Client Work Test', async ({ page }) => {
   // Step 1: Navigate to https://www.epam.com/
   await page.goto('https://www.epam.com/');


### PR DESCRIPTION
Added tests to navigate to EPAM website, select Services, click Explore Our Client Work, and verify the Client Work text is visible.