### PR TITLE
Add test for EPAM Client Work page

### DIFF
--- a/playwrighttests/test-epam-client-work.ts
+++ b/playwrighttests/test-epam-client-work.ts
@@ -1,0 +1,24 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  
+  // Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  await page.waitForTimeout(3000); // Wait for 3 seconds
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+  await page.waitForTimeout(3000); // Wait for 3 seconds
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+  await page.waitForTimeout(3000); // Wait for 3 seconds
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkVisible = await page.isVisible('text=Client Work');
+  console.assert(clientWorkVisible, 'Client Work text is not visible');
+
+  await browser.close();
+})();


### PR DESCRIPTION
Added a new test in the 'playwrighttests/' directory to verify the visibility of the "Client Work" text on the EPAM website.

### Test Scenario:
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

### Instruction for Test Scenario:
- Added waits for the steps.
