### PR TITLE
Add test scenario for EPAM website

### DIFF
--- a/testScenario.ts
+++ b/testScenario.ts
@@ -1,0 +1,34 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  // Launch browser
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+  await page.waitForTimeout(2000); // Wait for 2 seconds
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.isVisible('text=Client Work');
+  if (clientWorkText) {
+    console.log('Client Work text is visible on the page.');
+  } else {
+    console.log('Client Work text is NOT visible on the page.');
+  }
+
+  // Take a screenshot
+  await page.screenshot({ path: 'client_work.png' });
+
+  // Close browser
+  await browser.close();
+})();


### PR DESCRIPTION
This pull request adds a test scenario for the EPAM website using Playwright.

### Test Scenario:
1. Navigate to https://www.epam.com/
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.
5. Take a screenshot

### Instruction for Test Scenario:
- Add waits for the steps

The Typescript code for the test scenario is added in the file `testScenario.ts`.