### PR TITLE
[Kan-6] Add automated login & password reset test cases

### DIFF
--- a/tests/automated_test_scripts.py
+++ b/tests/automated_test_scripts.py
@@ -1,0 +1,64 @@
+import unittest
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+class LoginTests(unittest.TestCase):
+    def setUp(self):
+        self.driver = webdriver.Chrome()
+        self.driver.get("https://example.com/login")
+
+    def test_successful_login(self):
+        username = self.driver.find_element(By.ID, "username")
+        password = self.driver.find_element(By.ID, "password")
+        submit = self.driver.find_element(By.ID, "submit")
+
+        username.send_keys("testuser")
+        password.send_keys("testpassword")
+        submit.click()
+
+        WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.ID, "welcome-message"))
+        )
+        self.assertTrue(self.driver.find_element(By.ID, "welcome-message").is_displayed())
+
+    def test_failed_login(self):
+        username = self.driver.find_element(By.ID, "username")
+        password = self.driver.find_element(By.ID, "password")
+        submit = self.driver.find_element(By.ID, "submit")
+
+        username.send_keys("wronguser")
+        password.send_keys("wrongpassword")
+        submit.click()
+
+        WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.ID, "error-message"))
+        )
+        self.assertTrue(self.driver.find_element(By.ID, "error-message").is_displayed())
+
+    def tearDown(self):
+        self.driver.quit()
+
+class PasswordResetTests(unittest.TestCase):
+    def setUp(self):
+        self.driver = webdriver.Chrome()
+        self.driver.get("https://example.com/password-reset")
+
+    def test_password_reset_request(self):
+        email = self.driver.find_element(By.ID, "email")
+        submit = self.driver.find_element(By.ID, "reset-submit")
+
+        email.send_keys("testuser@example.com")
+        submit.click()
+
+        WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.ID, "confirmation-message"))
+        )
+        self.assertTrue(self.driver.find_element(By.ID, "confirmation-message").is_displayed())
+
+    def tearDown(self):
+        self.driver.quit()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This pull request adds automated test scripts for login and password reset functionality.

Reference to Jira ticket: Kan-6

New test classes and scenarios:
1. LoginTests
   - test_successful_login: Verifies successful login with correct credentials
   - test_failed_login: Verifies error message display with incorrect credentials

2. PasswordResetTests
   - test_password_reset_request: Verifies the password reset request process

These automated tests will help ensure the reliability and functionality of our login and password reset features.